### PR TITLE
Avoid breaking textmate highlighting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,9 @@ repositories {
 }
 
 dependencies {
-    intellijPlatform.rider("2025.1.2")
+    intellijPlatform.rider("2025.2")
     intellijPlatform.plugin("PsiViewer", "2025.1")
+    intellijPlatform.bundledPlugin("org.jetbrains.plugins.textmate")
 }
 
 intellijPlatform {
@@ -43,6 +44,7 @@ intellijPlatform {
             </ul>
         """.trimIndent()
     }
+    
 }
 
 tasks {

--- a/src/main/kotlin/kr/jaehoyi/gdshader/GDShaderFileType.kt
+++ b/src/main/kotlin/kr/jaehoyi/gdshader/GDShaderFileType.kt
@@ -1,9 +1,10 @@
 package kr.jaehoyi.gdshader
 
 import com.intellij.openapi.fileTypes.LanguageFileType
+import org.jetbrains.plugins.textmate.TextMateBackedFileType
 import javax.swing.Icon
 
-object GDShaderFileType : LanguageFileType(GDShaderLanguage) {
+object GDShaderFileType : LanguageFileType(GDShaderLanguage), TextMateBackedFileType {
     override fun getName(): String = "GDShader File"
 
     override fun getDescription(): String = "GDShader file"
@@ -11,4 +12,6 @@ object GDShaderFileType : LanguageFileType(GDShaderLanguage) {
     override fun getDefaultExtension(): String = "gdshader"
 
     override fun getIcon(): Icon = GDShaderIcons.GDSHADER
+
+    override fun getDisplayName(): String = "GDShader"
 }

--- a/src/main/kotlin/kr/jaehoyi/gdshader/GDShaderIncludeFileType.kt
+++ b/src/main/kotlin/kr/jaehoyi/gdshader/GDShaderIncludeFileType.kt
@@ -11,4 +11,6 @@ object GDShaderIncludeFileType : LanguageFileType(GDShaderLanguage) {
     override fun getDefaultExtension(): String = "gdshaderinc"
 
     override fun getIcon(): Icon = GDShaderIcons.GDSHADERINC
+
+    override fun getDisplayName(): String = "GDShaderInclude"
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
     </description>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>org.jetbrains.plugins.textmate</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         


### PR DESCRIPTION
Hello @akghxhs55,

Thank you for your plugin, I find it very useful!

I had a discussion with the maintainer of the official Godot plugin (see [https://github.com/JetBrains/godot-support/issues/292#issuecomment-3309349577](https://github.com/JetBrains/godot-support/issues/292#issuecomment-3309349577)). 
They suggested having `GDShaderFileType` implement `TextMateBackedFileType` to prevent conflicts with the official plugin, which also provides syntax highlighting for .gdshader files via [textmate](https://www.jetbrains.com/help/idea/2025.1/textmate.html).

With this change, both plugins can coexist. 
If your syntax highlighting misses some cases covered by the textmate plugin for vscode, textmate would be used as a fallback.

Tell me what you think about it :)